### PR TITLE
Fix nib outlet errors

### DIFF
--- a/src/macosx/English.lproj/AudioControls.xib
+++ b/src/macosx/English.lproj/AudioControls.xib
@@ -8,7 +8,6 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="AudioControlsWindowController">
             <connections>
-                <outlet property="fPlayDurationLabel" destination="1610" id="1647"/>
                 <outlet property="fPlayNameLabel" destination="1608" id="1648"/>
                 <outlet property="fPlayPosition" destination="1615" id="1791"/>
                 <outlet property="fPlayPositionLabel" destination="1609" id="1797"/>

--- a/src/macosx/English.lproj/MainMenu.xib
+++ b/src/macosx/English.lproj/MainMenu.xib
@@ -31,9 +31,6 @@
                             </menuItem>
                             <menuItem title="Donate..." hidden="YES" enabled="NO" id="926">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <connections>
-                                    <action selector="openDonate:" target="812" id="948"/>
-                                </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="236">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>


### PR DESCRIPTION
* Could not connect action, target class DocumentController does not respond to -openDonate:
* Failed to connect (fPlayDurationLabel) outlet from (AudioControlsWindowController) to (NSTextField): missing setter or instance variable

Fixes #4 